### PR TITLE
Home screen with grid of icons

### DIFF
--- a/src/home/HomeScreen.tsx
+++ b/src/home/HomeScreen.tsx
@@ -2,6 +2,7 @@ import {View} from 'react-native';
 import React from 'react';
 import {Header} from './components/Header';
 import {HomeButton} from './components/HomeButton';
+import {HOME_SCREEN_BUTTONS_DATASET} from './components/HomeButtonsData';
 
 export const HomeScreen = () => {
   return (

--- a/src/home/HomeScreen.tsx
+++ b/src/home/HomeScreen.tsx
@@ -10,24 +10,6 @@ export const HomeScreen = () => {
         headerImagePath={require('./components/img/headerBackground.jpg')}
         headerText="Companion"
       />
-      <HomeButton
-        label="Appuis : "
-        // clickHandler={() => {
-        //   console.log('Appui !');
-        // }}
-        imgPath={require('./components/img/tracker.png')}></HomeButton>
-      <HomeButton
-        label="Appuis : "
-        // clickHandler={() => {
-        //   console.log('Appui !');
-        // }}
-        imgPath={require('./components/img/my_village.png')}></HomeButton>
-      <HomeButton
-        label="Appuis : "
-        // clickHandler={() => {
-        //   console.log('Appui !');
-        // }}
-        imgPath={require('./components/img/encyclo_betes.png')}></HomeButton>
     </View>
   );
 };

--- a/src/home/HomeScreen.tsx
+++ b/src/home/HomeScreen.tsx
@@ -1,8 +1,10 @@
-import {View} from 'react-native';
+import {View, FlatList} from 'react-native';
 import React from 'react';
 import {Header} from './components/Header';
 import {HomeButton} from './components/HomeButton';
 import {HOME_SCREEN_BUTTONS_DATASET} from './components/HomeButtonsData';
+
+export const NUMBER_OF_COLUMNS = 3;
 
 export const HomeScreen = () => {
   return (
@@ -11,6 +13,19 @@ export const HomeScreen = () => {
         headerImagePath={require('./components/img/headerBackground.jpg')}
         headerText="Companion"
       />
+      <View style={styles.listWrapper}>
+        <FlatList
+          horizontal={false}
+          numColumns={NUMBER_OF_COLUMNS}
+          data={HOME_SCREEN_BUTTONS_DATASET}
+          renderItem={button => (
+            <HomeButton
+              label={button.item.label}
+              imgPath={button.item.imgPath}
+            />
+          )}
+        />
+      </View>
     </View>
   );
 };

--- a/src/home/HomeScreen.tsx
+++ b/src/home/HomeScreen.tsx
@@ -1,10 +1,12 @@
-import {View, FlatList} from 'react-native';
+import {StyleSheet, View, FlatList} from 'react-native';
 import React from 'react';
 import {Header} from './components/Header';
 import {HomeButton} from './components/HomeButton';
 import {HOME_SCREEN_BUTTONS_DATASET} from './components/HomeButtonsData';
 
 export const NUMBER_OF_COLUMNS = 3;
+export const MAX_GRID_WIDTH = 500;
+export const GRID_WIDTH_RATIO = 0.9;
 
 export const HomeScreen = () => {
   return (
@@ -29,3 +31,11 @@ export const HomeScreen = () => {
     </View>
   );
 };
+
+const styles = StyleSheet.create({
+  listWrapper: {
+    alignSelf: 'center',
+    width: `${GRID_WIDTH_RATIO * 100}%`,
+    maxWidth: MAX_GRID_WIDTH,
+  },
+});

--- a/src/home/components/Header.tsx
+++ b/src/home/components/Header.tsx
@@ -2,7 +2,7 @@ import {StyleSheet, Text, View, ImageBackground} from 'react-native';
 import React from 'react';
 
 const HEADER_HEIGHT = 60;
-const HEADER_BOTTOM_MARGIN = 20;
+const HEADER_BOTTOM_MARGIN = 40;
 const HEADER_FONT_SIZE = 30;
 
 export const Header = ({

--- a/src/home/components/HomeButton.tsx
+++ b/src/home/components/HomeButton.tsx
@@ -1,8 +1,25 @@
-import {StyleSheet, View, TouchableOpacity, Image, Text} from 'react-native';
+import {
+  StyleSheet,
+  View,
+  TouchableOpacity,
+  Image,
+  Text,
+  Dimensions,
+} from 'react-native';
 import React, {useState} from 'react';
+import {
+  MAX_GRID_WIDTH,
+  GRID_WIDTH_RATIO,
+  NUMBER_OF_COLUMNS,
+} from '../HomeScreen';
 
 const BUTTON_TOTAL_HEIGHT = 160;
-const BUTTON_TOTAL_WIDTH = 120;
+
+const BUTTON_TOTAL_WIDTH =
+  Dimensions.get('window').width > MAX_GRID_WIDTH
+    ? (MAX_GRID_WIDTH * GRID_WIDTH_RATIO) / NUMBER_OF_COLUMNS
+    : (GRID_WIDTH_RATIO * Dimensions.get('window').width) / NUMBER_OF_COLUMNS;
+
 const BUTTON_ICON_HEIGHT_AND_WIDTH = 100;
 
 export const HomeButton = ({

--- a/src/home/components/HomeButtonsData.tsx
+++ b/src/home/components/HomeButtonsData.tsx
@@ -1,0 +1,18 @@
+export const HOME_SCREEN_BUTTONS_DATASET = [
+  {
+    label: 'Encyclopédie',
+    imgPath: require('./img/encyclo_betes.png'),
+  },
+  {
+    label: 'Tracker',
+    imgPath: require('./img/tracker.png'),
+  },
+  {
+    label: 'Fossiles',
+    imgPath: require('./img/encyclo_fossiles.png'),
+  },
+  {
+    label: 'Mon Village',
+    imgPath: require('./img/my_village.png'),
+  },
+];


### PR DESCRIPTION
The goal was to standardize the home screen and the button management with a grid. To do this, I used a FlatList from React Native and made it a 3 columns list. To manage the size of the buttons, I use either the dimension of the screen, or a max width set to 500.



| Before  | After |
| ------------- | ------------- |
|  ![Screenshot_1676022791](https://user-images.githubusercontent.com/103206306/218060793-e86c9fc1-65b9-4a81-8253-80109869100e.png) | ![Screenshot_1676022647](https://user-images.githubusercontent.com/103206306/218060633-fa775c40-88b8-4860-802e-19d90d3253c2.png) |