### PR TITLE
Feature/AC-03 : ETQU je peux afficher des informations

### DIFF
--- a/src/pages/common/components/ExpandableView.tsx
+++ b/src/pages/common/components/ExpandableView.tsx
@@ -1,0 +1,76 @@
+import {useState, useEffect} from 'react';
+import {Animated, TouchableHighlight, StyleSheet, View} from 'react-native';
+
+interface Props {
+  topView: JSX.Element;
+  expandView: JSX.Element;
+}
+
+export const ExpandableView = ({topView, expandView}: Props) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [marginTop] = useState(new Animated.Value(0));
+
+  useEffect(() => {
+    Animated.timing(marginTop, {
+      toValue: isExpanded ? 0 : -101,
+      duration: 150,
+      useNativeDriver: false,
+    }).start();
+  }, [isExpanded, marginTop]);
+
+  return (
+    <View style={styles.wrapper}>
+      <TouchableHighlight
+        onPress={() => {
+          setIsExpanded(!isExpanded);
+        }}
+        style={styles.touchableContainer}>
+        <View style={styles.animalCard}>{topView}</View>
+      </TouchableHighlight>
+      <Animated.View style={[{marginTop}, styles.expandView]}>
+        {expandView}
+      </Animated.View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  animalCard: {
+    width: '100%',
+    backgroundColor: '#FAEDCD',
+    borderColor: '#D4A373',
+    borderRadius: 10,
+    borderWidth: 3,
+    padding: 8,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  touchableContainer: {
+    borderRadius: 10,
+    width: '100%',
+    zIndex: 1,
+  },
+  expandView: {
+    justifyContent: 'space-evenly',
+    height: 100,
+    width: '90%',
+    alignSelf: 'center',
+    backgroundColor: '#FAEDCD',
+    padding: 5,
+    borderBottomColor: '#D4A373',
+    borderLeftColor: '#D4A373',
+    borderRightColor: '#D4A373',
+    borderBottomLeftRadius: 10,
+    borderBottomRightRadius: 10,
+    borderBottomWidth: 3,
+    borderLeftWidth: 3,
+    borderRightWidth: 3,
+  },
+  wrapper: {
+    width: '90%',
+    justifyContent: 'center',
+    alignContent: 'center',
+    alignSelf: 'center',
+    marginVertical: 5,
+  },
+});

--- a/src/pages/common/functions/CapitalizeString.tsx
+++ b/src/pages/common/functions/CapitalizeString.tsx
@@ -1,0 +1,15 @@
+export const CapitalizeFirstLetters = (string: string) => {
+  const arrayWithEachWord = string.split(' ');
+  for (
+    var wordToCapitalize = 0;
+    wordToCapitalize < arrayWithEachWord.length;
+    wordToCapitalize++
+  ) {
+    arrayWithEachWord[wordToCapitalize] =
+      arrayWithEachWord[wordToCapitalize].charAt(0).toUpperCase() +
+      arrayWithEachWord[wordToCapitalize].slice(1);
+  }
+
+  const stringWithEachWordFirstLetterCapitalized = arrayWithEachWord.join(' ');
+  return stringWithEachWordFirstLetterCapitalized;
+};

--- a/src/pages/common/functions/FormatDateIntervalIntoString.tsx
+++ b/src/pages/common/functions/FormatDateIntervalIntoString.tsx
@@ -1,0 +1,22 @@
+export const FormatDateIntervalIntoString = (availability: string) => {
+  if (availability == '') {
+    return "Toute l'année";
+  }
+
+  let textToShow = availability
+    .replace('10', 'Octobre')
+    .replace('11', 'Novembre')
+    .replace('12', 'Décembre')
+    .replace('1', 'Janvier')
+    .replace('2', 'Février')
+    .replace('3', 'Mars')
+    .replace('4', 'Avril')
+    .replace('5', 'Mai')
+    .replace('6', 'Juin')
+    .replace('7', 'Juillet')
+    .replace('8', 'Aout')
+    .replace('9', 'Septembre')
+    .replace('-', ' à ')
+    .replace('-', ' à ');
+  return textToShow;
+};

--- a/src/pages/common/functions/ShowAvailabilityHours.tsx
+++ b/src/pages/common/functions/ShowAvailabilityHours.tsx
@@ -1,0 +1,7 @@
+export const ShowAvailabilityhours = (availability: string) => {
+  let textToShow = '';
+  availability == ''
+    ? (textToShow = 'Toute la journée')
+    : (textToShow = availability);
+  return textToShow;
+};

--- a/src/pages/encyclopedie/Encyclopedie.tsx
+++ b/src/pages/encyclopedie/Encyclopedie.tsx
@@ -1,4 +1,4 @@
-import {View, StyleSheet, Image, ImageSourcePropType} from 'react-native';
+import {View, Image, ImageSourcePropType} from 'react-native';
 import {Header} from '../header/Header';
 import type {Bug, Fish} from './Types';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
@@ -112,31 +112,3 @@ const iconOptions = (icon: ImageSourcePropType) => {
     },
   };
 };
-
-export const styles = StyleSheet.create({
-  animalCard: {
-    width: '90%',
-    alignSelf: 'center',
-    backgroundColor: '#FAEDCD',
-    borderColor: '#D4A373',
-    borderRadius: 10,
-    borderWidth: 3,
-    margin: 5,
-    padding: 8,
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  animalID: {
-    flex: 1,
-    justifyContent: 'space-evenly',
-  },
-  animalImage: {
-    width: '100%',
-    height: '100%',
-  },
-  animalImageContainer: {
-    width: 80,
-    height: 80,
-    margin: 5,
-  },
-});

--- a/src/pages/encyclopedie/components/BottomViewBugs.tsx
+++ b/src/pages/encyclopedie/components/BottomViewBugs.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import {SimpleTypography} from '../../../theme/typography/Typography';
+import {FormatDateIntervalIntoString} from '../../common/functions/FormatDateIntervalIntoString';
+import {ShowAvailabilityhours} from '../../common/functions/ShowAvailabilityHours';
 
 interface BottomViewBugsProps {
   months: string;
@@ -13,8 +15,10 @@ export const BottomViewBugs = ({
 }: BottomViewBugsProps) => {
   return (
     <>
-      <SimpleTypography text={'Disponibilité : ' + months} />
-      <SimpleTypography text={'Horaire : ' + hours} />
+      <SimpleTypography
+        text={'Disponibilité : ' + FormatDateIntervalIntoString(months)}
+      />
+      <SimpleTypography text={'Horaire : ' + ShowAvailabilityhours(hours)} />
       <SimpleTypography text={'Localisation : ' + location} />
     </>
   );

--- a/src/pages/encyclopedie/components/BottomViewBugs.tsx
+++ b/src/pages/encyclopedie/components/BottomViewBugs.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import {SimpleTypography} from '../../../theme/typography/Typography';
+
+interface BottomViewBugsProps {
+  months: string;
+  hours: string;
+  location: string;
+}
+export const BottomViewBugs = ({
+  months,
+  hours,
+  location,
+}: BottomViewBugsProps) => {
+  return (
+    <>
+      <SimpleTypography text={'Disponibilité : ' + months} />
+      <SimpleTypography text={'Horaire : ' + hours} />
+      <SimpleTypography text={'Localisation : ' + location} />
+    </>
+  );
+};

--- a/src/pages/encyclopedie/components/BottomViewFish.tsx
+++ b/src/pages/encyclopedie/components/BottomViewFish.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import {SimpleTypography} from '../../../theme/typography/Typography';
+import {ShowAvailabilityhours} from '../../common/functions/ShowAvailabilityHours';
+import {FormatDateIntervalIntoString} from '../../common/functions/FormatDateIntervalIntoString';
 
 interface BottomViewFishProps {
   months: string;
@@ -15,8 +17,10 @@ export const BottomViewFish = ({
 }: BottomViewFishProps) => {
   return (
     <>
-      <SimpleTypography text={'Disponibilité : ' + months} />
-      <SimpleTypography text={'Horaire : ' + hours} />
+      <SimpleTypography
+        text={'Disponibilité : ' + FormatDateIntervalIntoString(months)}
+      />
+      <SimpleTypography text={'Horaire : ' + ShowAvailabilityhours(hours)} />
       <SimpleTypography text={'Localisation : ' + location} />
       <SimpleTypography text={'Ombre : ' + shadow} />
     </>

--- a/src/pages/encyclopedie/components/BottomViewFish.tsx
+++ b/src/pages/encyclopedie/components/BottomViewFish.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import {SimpleTypography} from '../../../theme/typography/Typography';
+
+interface BottomViewFishProps {
+  months: string;
+  hours: string;
+  location: string;
+  shadow: string;
+}
+export const BottomViewFish = ({
+  months,
+  hours,
+  location,
+  shadow,
+}: BottomViewFishProps) => {
+  return (
+    <>
+      <SimpleTypography text={'Disponibilité : ' + months} />
+      <SimpleTypography text={'Horaire : ' + hours} />
+      <SimpleTypography text={'Localisation : ' + location} />
+      <SimpleTypography text={'Ombre : ' + shadow} />
+    </>
+  );
+};

--- a/src/pages/encyclopedie/components/BugListScrollView.tsx
+++ b/src/pages/encyclopedie/components/BugListScrollView.tsx
@@ -1,9 +1,11 @@
-import {View, Image, FlatList} from 'react-native';
+import {FlatList} from 'react-native';
 import React from 'react';
 import type {Bug} from '../Types';
-import {SimpleTypography} from '../../../theme/typography/Typography';
-import {styles, TabStackParamList} from '../Encyclopedie';
+import {TabStackParamList} from '../Encyclopedie';
 import {RouteProp} from '@react-navigation/native';
+import {ExpandableView} from '../../common/components/ExpandableView';
+import {TopViewAnimal} from './TopViewAnimal';
+import {BottomViewBugs} from './BottomViewBugs';
 
 type BugListRouteProp = RouteProp<TabStackParamList, 'Bug'>;
 
@@ -18,23 +20,23 @@ export function BugListScrollView({route}: BugProps) {
       horizontal={false}
       data={bugList}
       renderItem={bug => (
-        <View style={styles.animalCard}>
-          <View style={styles.animalID}>
-            <SimpleTypography text={'Name : ' + bug.item.name['name-USen']} />
-            <SimpleTypography
-              text={'Rarity : ' + bug.item.availability.rarity}
+        <ExpandableView
+          topView={
+            <TopViewAnimal
+              name={bug.item.name['name-EUfr']}
+              rarity={bug.item.availability.rarity}
+              price={bug.item.price}
+              icon={bug.item.icon_uri}
             />
-            <SimpleTypography text={'Price : ' + bug.item.price + ' bells'} />
-          </View>
-          <View style={styles.animalImageContainer}>
-            <Image
-              style={styles.animalImage}
-              source={{
-                uri: bug.item.icon_uri,
-              }}
+          }
+          expandView={
+            <BottomViewBugs
+              months={bug.item.availability['month-northern']}
+              hours={bug.item.availability.time}
+              location={bug.item.availability.location}
             />
-          </View>
-        </View>
+          }
+        />
       )}
     />
   );

--- a/src/pages/encyclopedie/components/BugListScrollView.tsx
+++ b/src/pages/encyclopedie/components/BugListScrollView.tsx
@@ -6,6 +6,7 @@ import {RouteProp} from '@react-navigation/native';
 import {ExpandableView} from '../../common/components/ExpandableView';
 import {TopViewAnimal} from './TopViewAnimal';
 import {BottomViewBugs} from './BottomViewBugs';
+import {CapitalizeFirstLetters} from '../../common/functions/CapitalizeString';
 
 type BugListRouteProp = RouteProp<TabStackParamList, 'Bug'>;
 
@@ -23,7 +24,7 @@ export function BugListScrollView({route}: BugProps) {
         <ExpandableView
           topView={
             <TopViewAnimal
-              name={bug.item.name['name-EUfr']}
+              name={CapitalizeFirstLetters(bug.item.name['name-EUfr'])}
               rarity={bug.item.availability.rarity}
               price={bug.item.price}
               icon={bug.item.icon_uri}

--- a/src/pages/encyclopedie/components/FishListScrollView.tsx
+++ b/src/pages/encyclopedie/components/FishListScrollView.tsx
@@ -1,9 +1,11 @@
-import {View, Image, FlatList} from 'react-native';
+import {FlatList} from 'react-native';
 import React from 'react';
 import type {Fish} from '../Types';
-import {SimpleTypography} from '../../../theme/typography/Typography';
-import {styles, TabStackParamList} from '../Encyclopedie';
+import {TabStackParamList} from '../Encyclopedie';
 import {RouteProp} from '@react-navigation/native';
+import {ExpandableView} from '../../common/components/ExpandableView';
+import {BottomViewFish} from './BottomViewFish';
+import {TopViewAnimal} from './TopViewAnimal';
 
 type FishListRouteProp = RouteProp<TabStackParamList, 'Fish'>;
 
@@ -18,23 +20,24 @@ export function FishListScrollView({route}: FishProps) {
       horizontal={false}
       data={fishList}
       renderItem={fish => (
-        <View style={styles.animalCard}>
-          <View style={styles.animalID}>
-            <SimpleTypography text={'Name : ' + fish.item.name['name-USen']} />
-            <SimpleTypography
-              text={'Rarity : ' + fish.item.availability.rarity}
+        <ExpandableView
+          topView={
+            <TopViewAnimal
+              name={fish.item.name['name-EUfr']}
+              rarity={fish.item.availability.rarity}
+              price={fish.item.price}
+              icon={fish.item.icon_uri}
             />
-            <SimpleTypography text={'Price : ' + fish.item.price + ' bells'} />
-          </View>
-          <View style={styles.animalImageContainer}>
-            <Image
-              style={styles.animalImage}
-              source={{
-                uri: fish.item.icon_uri,
-              }}
+          }
+          expandView={
+            <BottomViewFish
+              months={fish.item.availability['month-northern']}
+              hours={fish.item.availability.time}
+              location={fish.item.availability.location}
+              shadow={fish.item.shadow}
             />
-          </View>
-        </View>
+          }
+        />
       )}
     />
   );

--- a/src/pages/encyclopedie/components/FishListScrollView.tsx
+++ b/src/pages/encyclopedie/components/FishListScrollView.tsx
@@ -6,6 +6,7 @@ import {RouteProp} from '@react-navigation/native';
 import {ExpandableView} from '../../common/components/ExpandableView';
 import {BottomViewFish} from './BottomViewFish';
 import {TopViewAnimal} from './TopViewAnimal';
+import {CapitalizeFirstLetters} from '../../common/functions/CapitalizeString';
 
 type FishListRouteProp = RouteProp<TabStackParamList, 'Fish'>;
 
@@ -23,7 +24,7 @@ export function FishListScrollView({route}: FishProps) {
         <ExpandableView
           topView={
             <TopViewAnimal
-              name={fish.item.name['name-EUfr']}
+              name={CapitalizeFirstLetters(fish.item.name['name-EUfr'])}
               rarity={fish.item.availability.rarity}
               price={fish.item.price}
               icon={fish.item.icon_uri}

--- a/src/pages/encyclopedie/components/TopViewAnimal.tsx
+++ b/src/pages/encyclopedie/components/TopViewAnimal.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import {View, Image} from 'react-native';
+import {SimpleTypography} from '../../../theme/typography/Typography';
+import {StyleSheet} from 'react-native';
+
+interface TopViewProps {
+  name: string;
+  rarity: string;
+  price: number;
+  icon: string;
+}
+export const TopViewAnimal = ({name, rarity, price, icon}: TopViewProps) => {
+  return (
+    <>
+      <View style={styles.animalID}>
+        <SimpleTypography text={'Nom : ' + name} />
+        <SimpleTypography text={'Rareté : ' + rarity} />
+        <SimpleTypography text={'Prix : ' + price} />
+      </View>
+      <View style={styles.animalImageContainer}>
+        <Image
+          style={styles.animalImage}
+          source={{
+            uri: icon,
+          }}
+        />
+      </View>
+    </>
+  );
+};
+
+const styles = StyleSheet.create({
+  animalCard: {
+    width: '90%',
+    alignSelf: 'center',
+    backgroundColor: '#FAEDCD',
+    borderColor: '#D4A373',
+    borderRadius: 10,
+    borderWidth: 3,
+    margin: 5,
+    padding: 8,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  animalID: {
+    flex: 1,
+    justifyContent: 'space-evenly',
+  },
+  animalImage: {
+    width: '100%',
+    height: '100%',
+  },
+  animalImageContainer: {
+    width: 80,
+    height: 80,
+    margin: 5,
+  },
+});


### PR DESCRIPTION
This pull request aims to add the feature to have a drawer on fish and bug tabs which shows additional information.

It contains : 
- The creation of new component "ExpandableView" which is the merge between the old fish & bug cards and the drawer (named bottomview)
- The creation of said drawer with information from API
- Some file arrangement

| Before  | After |
| ------------- | ------------- |
| ![223458436-6b7ddde0-2051-40a6-b190-84409164a9c5](https://user-images.githubusercontent.com/103206306/228583720-3f4af9f2-f623-45c4-b873-271ebfd54462.gif) | ![ezgif-5-200ce3ff5d](https://user-images.githubusercontent.com/103206306/228583704-b2463a3e-6c80-4ac7-a516-4433b1d25e6b.gif) | ![223458436-6b7ddde0-2051-40a6-b190-84409164a9c5](https://user-images.githubusercontent.com/103206306/228583720-3f4af9f2-f623-45c4-b873-271ebfd54462.gif) |