### PR TITLE
Refacto/single-scrollview-component

### DIFF
--- a/src/pages/common/functions/AdaptAnimalData.test.tsx
+++ b/src/pages/common/functions/AdaptAnimalData.test.tsx
@@ -10,8 +10,8 @@ describe('AdaptAnimalData', () => {
         'name-EUfr': 'PoissonPilote',
       },
       availability: {
-        'month-northern': '4 - 9',
-        'month-southern': '4 - 9',
+        'month-northern': '4-9',
+        'month-southern': '4-9',
         'month-array-northern': [1, 2],
         'month-array-southern': [1, 2],
         time: '9am - 4pm',

--- a/src/pages/common/functions/AdaptAnimalData.tsx
+++ b/src/pages/common/functions/AdaptAnimalData.tsx
@@ -1,4 +1,5 @@
 import {Bug, Fish} from '../../encyclopedie/Types';
+import {CapitalizeFirstLetters} from './CapitalizeString';
 import {FormatDateIntervalIntoString} from './FormatDateIntervalIntoString';
 import {FormatHoursIntervalIntoString} from './FormatHoursIntervalIntoString';
 
@@ -9,4 +10,5 @@ export const AdaptAnimalData = (animal: Fish | Bug) => {
   animal.availability.time = FormatHoursIntervalIntoString(
     animal.availability.time,
   );
+  animal.name['name-EUfr'] = CapitalizeFirstLetters(animal.name['name-EUfr']);
 };

--- a/src/pages/common/functions/FormatDateIntervalIntoString.test.tsx
+++ b/src/pages/common/functions/FormatDateIntervalIntoString.test.tsx
@@ -2,7 +2,7 @@ import {FormatDateIntervalIntoString} from './FormatDateIntervalIntoString';
 
 describe('FormatDateIntervalIntoString', () => {
   it('should return the formatted date interval when the input is not empty', () => {
-    const input = '9 - 6';
+    const input = '9-6';
     const expectedResult = 'Septembre à Juin';
 
     const result = FormatDateIntervalIntoString(input);
@@ -20,7 +20,7 @@ describe('FormatDateIntervalIntoString', () => {
   });
 
   it('should handle date intervals spanning from a single-digit month to a double-digit month', () => {
-    const input = '8 - 11';
+    const input = '8-11';
     const expectedResult = 'Aout à Novembre';
 
     const result = FormatDateIntervalIntoString(input);
@@ -29,7 +29,7 @@ describe('FormatDateIntervalIntoString', () => {
   });
 
   it('should handle date intervals spanning from a double-digit month to a single-digit month', () => {
-    const input = '10 - 3';
+    const input = '10-3';
     const expectedResult = 'Octobre à Mars';
 
     const result = FormatDateIntervalIntoString(input);

--- a/src/pages/common/functions/FormatDateIntervalIntoString.tsx
+++ b/src/pages/common/functions/FormatDateIntervalIntoString.tsx
@@ -16,7 +16,7 @@ export const FormatDateIntervalIntoString = (availability: string) => {
     .replace('7', 'Juillet')
     .replace('8', 'Aout')
     .replace('9', 'Septembre')
-    .replace('-', 'à')
-    .replace('-', 'à');
+    .replace('-', ' à ')
+    .replace('-', ' à ');
   return textToShow;
 };

--- a/src/pages/encyclopedie/components/AnimalScrollView.tsx
+++ b/src/pages/encyclopedie/components/AnimalScrollView.tsx
@@ -1,0 +1,69 @@
+import {FlatList, ActivityIndicator} from 'react-native';
+import {ExpandableView} from '../../common/components/ExpandableView';
+import {Fish, Bug} from '../Types';
+import {BottomViewBugs} from './BottomViewBugs';
+import {TopViewAnimal} from './TopViewAnimal';
+import {BottomViewFish} from './BottomViewFish';
+import React from 'react';
+
+type AnimalProps = {type: 'fish'; data: Fish[]} | {type: 'bug'; data: Bug[]};
+
+export const AnimalScrollView = ({type, data}: AnimalProps) => {
+  if (type === 'fish') {
+    return (
+      <FlatList
+        horizontal={false}
+        data={data}
+        renderItem={animal => (
+          <ExpandableView
+            topView={
+              <TopViewAnimal
+                name={animal.item.name['name-EUfr']}
+                rarity={animal.item.availability.rarity}
+                price={animal.item.price}
+                icon={animal.item.icon_uri}
+              />
+            }
+            expandView={
+              <BottomViewFish
+                months={animal.item.availability['month-northern']}
+                hours={animal.item.availability.time}
+                location={animal.item.availability.location}
+                shadow={animal.item.shadow}
+              />
+            }
+          />
+        )}
+      />
+    );
+  }
+  if (type === 'bug') {
+    return (
+      <FlatList
+        horizontal={false}
+        data={data}
+        renderItem={animal => (
+          <ExpandableView
+            topView={
+              <TopViewAnimal
+                name={animal.item.name['name-EUfr']}
+                rarity={animal.item.availability.rarity}
+                price={animal.item.price}
+                icon={animal.item.icon_uri}
+              />
+            }
+            expandView={
+              <BottomViewBugs
+                months={animal.item.availability['month-northern']}
+                hours={animal.item.availability.time}
+                location={animal.item.availability.location}
+              />
+            }
+          />
+        )}
+      />
+    );
+  } else {
+    return <ActivityIndicator />;
+  }
+};

--- a/src/pages/encyclopedie/components/AnimalScrollView.tsx
+++ b/src/pages/encyclopedie/components/AnimalScrollView.tsx
@@ -16,22 +16,8 @@ export const AnimalScrollView = ({type, data}: AnimalProps) => {
         data={data}
         renderItem={animal => (
           <ExpandableView
-            topView={
-              <TopViewAnimal
-                name={animal.item.name['name-EUfr']}
-                rarity={animal.item.availability.rarity}
-                price={animal.item.price}
-                icon={animal.item.icon_uri}
-              />
-            }
-            expandView={
-              <BottomViewFish
-                months={animal.item.availability['month-northern']}
-                hours={animal.item.availability.time}
-                location={animal.item.availability.location}
-                shadow={animal.item.shadow}
-              />
-            }
+            topView={<TopViewAnimal animal={animal.item} />}
+            expandView={<BottomViewFish animal={animal.item} />}
           />
         )}
       />
@@ -44,21 +30,8 @@ export const AnimalScrollView = ({type, data}: AnimalProps) => {
         data={data}
         renderItem={animal => (
           <ExpandableView
-            topView={
-              <TopViewAnimal
-                name={animal.item.name['name-EUfr']}
-                rarity={animal.item.availability.rarity}
-                price={animal.item.price}
-                icon={animal.item.icon_uri}
-              />
-            }
-            expandView={
-              <BottomViewBugs
-                months={animal.item.availability['month-northern']}
-                hours={animal.item.availability.time}
-                location={animal.item.availability.location}
-              />
-            }
+            topView={<TopViewAnimal animal={animal.item} />}
+            expandView={<BottomViewBugs animal={animal.item} />}
           />
         )}
       />

--- a/src/pages/encyclopedie/components/BottomViewBugs.test.tsx
+++ b/src/pages/encyclopedie/components/BottomViewBugs.test.tsx
@@ -3,7 +3,7 @@ import {render, screen} from '@testing-library/react-native';
 import {BottomViewBugs} from './BottomViewBugs';
 import {Bug} from '../Types';
 
-const mockFishArray: Bug[] = [
+const mockBugArray: Bug[] = [
   {
     id: 1,
     name: {
@@ -29,13 +29,7 @@ const mockFishArray: Bug[] = [
 ];
 
 test('animal bottom view card with mock bug information', async () => {
-  render(
-    <BottomViewBugs
-      months={mockFishArray[0].availability['month-northern']}
-      hours={mockFishArray[0].availability.time}
-      location={mockFishArray[0].availability.location}
-    />,
-  );
+  render(<BottomViewBugs animal={mockBugArray[0]} />);
 
   const monthsOutput = screen.getByText('Disponibilité : Avril à Septembre');
   const hoursOutput = screen.getByText('Horaire  : 9am - 4pm');

--- a/src/pages/encyclopedie/components/BottomViewBugs.tsx
+++ b/src/pages/encyclopedie/components/BottomViewBugs.tsx
@@ -1,21 +1,21 @@
 import React from 'react';
 import {SimpleTypography} from '../../../theme/typography/Typography';
+import {Bug} from '../Types';
 
 interface BottomViewBugsProps {
-  months: string;
-  hours: string;
-  location: string;
+  animal: Bug;
 }
-export const BottomViewBugs = ({
-  months,
-  hours,
-  location,
-}: BottomViewBugsProps) => {
+
+export const BottomViewBugs = ({animal}: BottomViewBugsProps) => {
   return (
     <>
-      <SimpleTypography text={'Disponibilité : ' + months} />
-      <SimpleTypography text={'Horaire : ' + hours} />
-      <SimpleTypography text={'Localisation : ' + location} />
+      <SimpleTypography
+        text={'Disponibilité : ' + animal.availability['month-northern']}
+      />
+      <SimpleTypography text={'Horaire : ' + animal.availability.time} />
+      <SimpleTypography
+        text={'Localisation : ' + animal.availability.location}
+      />
     </>
   );
 };

--- a/src/pages/encyclopedie/components/BottomViewFish.test.tsx
+++ b/src/pages/encyclopedie/components/BottomViewFish.test.tsx
@@ -30,14 +30,7 @@ const mockFishArray: Fish[] = [
 ];
 
 test('animal bottom view card with mock fish information', async () => {
-  render(
-    <BottomViewFish
-      months={mockFishArray[0].availability['month-northern']}
-      hours={mockFishArray[0].availability.time}
-      location={mockFishArray[0].availability.location}
-      shadow={mockFishArray[0].shadow}
-    />,
-  );
+  render(<BottomViewFish animal={mockFishArray[0]} />);
 
   const monthsOutput = screen.getByText('Disponibilité : Avril à Septembre');
   const hoursOutput = screen.getByText('Horaire  : 9am - 4pm');

--- a/src/pages/encyclopedie/components/BottomViewFish.tsx
+++ b/src/pages/encyclopedie/components/BottomViewFish.tsx
@@ -1,24 +1,22 @@
 import React from 'react';
 import {SimpleTypography} from '../../../theme/typography/Typography';
+import {Fish} from '../Types';
 
 interface BottomViewFishProps {
-  months: string;
-  hours: string;
-  location: string;
-  shadow: string;
+  animal: Fish;
 }
-export const BottomViewFish = ({
-  months,
-  hours,
-  location,
-  shadow,
-}: BottomViewFishProps) => {
+
+export const BottomViewFish = ({animal}: BottomViewFishProps) => {
   return (
     <>
-      <SimpleTypography text={'Disponibilité : ' + months} />
-      <SimpleTypography text={'Horaire : ' + hours} />
-      <SimpleTypography text={'Localisation : ' + location} />
-      <SimpleTypography text={'Ombre : ' + shadow} />
+      <SimpleTypography
+        text={'Disponibilité : ' + animal.availability['month-northern']}
+      />
+      <SimpleTypography text={'Horaire : ' + animal.availability.time} />
+      <SimpleTypography
+        text={'Localisation : ' + animal.availability.location}
+      />
+      <SimpleTypography text={'Ombre : ' + animal.shadow} />
     </>
   );
 };

--- a/src/pages/encyclopedie/components/BugListScrollView.tsx
+++ b/src/pages/encyclopedie/components/BugListScrollView.tsx
@@ -1,12 +1,7 @@
-import {FlatList} from 'react-native';
-import React from 'react';
 import type {Bug} from '../Types';
 import {TabStackParamList} from '../Encyclopedie';
 import {RouteProp} from '@react-navigation/native';
-import {ExpandableView} from '../../common/components/ExpandableView';
-import {TopViewAnimal} from './TopViewAnimal';
-import {BottomViewBugs} from './BottomViewBugs';
-import {CapitalizeFirstLetters} from '../../common/functions/CapitalizeString';
+import {AnimalScrollView} from './AnimalScrollView';
 
 type BugListRouteProp = RouteProp<TabStackParamList, 'Bug'>;
 
@@ -16,29 +11,5 @@ type BugProps = {
 
 export function BugListScrollView({route}: BugProps) {
   const bugList: Bug[] = route.params.bugList;
-  return (
-    <FlatList
-      horizontal={false}
-      data={bugList}
-      renderItem={bug => (
-        <ExpandableView
-          topView={
-            <TopViewAnimal
-              name={CapitalizeFirstLetters(bug.item.name['name-EUfr'])}
-              rarity={bug.item.availability.rarity}
-              price={bug.item.price}
-              icon={bug.item.icon_uri}
-            />
-          }
-          expandView={
-            <BottomViewBugs
-              months={bug.item.availability['month-northern']}
-              hours={bug.item.availability.time}
-              location={bug.item.availability.location}
-            />
-          }
-        />
-      )}
-    />
-  );
+  return <AnimalScrollView type="bug" data={bugList} />;
 }

--- a/src/pages/encyclopedie/components/FishListScrollView.tsx
+++ b/src/pages/encyclopedie/components/FishListScrollView.tsx
@@ -1,12 +1,7 @@
-import {FlatList} from 'react-native';
-import React from 'react';
 import type {Fish} from '../Types';
 import {TabStackParamList} from '../Encyclopedie';
 import {RouteProp} from '@react-navigation/native';
-import {ExpandableView} from '../../common/components/ExpandableView';
-import {BottomViewFish} from './BottomViewFish';
-import {TopViewAnimal} from './TopViewAnimal';
-import {CapitalizeFirstLetters} from '../../common/functions/CapitalizeString';
+import {AnimalScrollView} from './AnimalScrollView';
 
 type FishListRouteProp = RouteProp<TabStackParamList, 'Fish'>;
 
@@ -16,30 +11,5 @@ type FishProps = {
 
 export function FishListScrollView({route}: FishProps) {
   const fishList: Fish[] = route.params.fishList;
-  return (
-    <FlatList
-      horizontal={false}
-      data={fishList}
-      renderItem={fish => (
-        <ExpandableView
-          topView={
-            <TopViewAnimal
-              name={CapitalizeFirstLetters(fish.item.name['name-EUfr'])}
-              rarity={fish.item.availability.rarity}
-              price={fish.item.price}
-              icon={fish.item.icon_uri}
-            />
-          }
-          expandView={
-            <BottomViewFish
-              months={fish.item.availability['month-northern']}
-              hours={fish.item.availability.time}
-              location={fish.item.availability.location}
-              shadow={fish.item.shadow}
-            />
-          }
-        />
-      )}
-    />
-  );
+  return <AnimalScrollView type="fish" data={fishList} />;
 }

--- a/src/pages/encyclopedie/components/TopViewAnimal.test.tsx
+++ b/src/pages/encyclopedie/components/TopViewAnimal.test.tsx
@@ -32,10 +32,7 @@ const mockFishArray: Fish[] = [
 test('animal top view card with mock fish information', async () => {
   render(
     <TopViewAnimal
-      name={mockFishArray[0].name['name-EUfr']}
-      rarity={mockFishArray[0].availability.rarity}
-      price={mockFishArray[0].price}
-      icon={mockFishArray[0].icon_uri}
+      animal={mockFishArray[0]}
     />,
   );
 

--- a/src/pages/encyclopedie/components/TopViewAnimal.tsx
+++ b/src/pages/encyclopedie/components/TopViewAnimal.tsx
@@ -2,26 +2,25 @@ import React from 'react';
 import {View, Image} from 'react-native';
 import {SimpleTypography} from '../../../theme/typography/Typography';
 import {StyleSheet} from 'react-native';
+import {Fish, Bug} from '../Types';
 
 interface TopViewProps {
-  name: string;
-  rarity: string;
-  price: number;
-  icon: string;
+  animal: Fish | Bug;
 }
-export const TopViewAnimal = ({name, rarity, price, icon}: TopViewProps) => {
+
+export const TopViewAnimal = ({animal}: TopViewProps) => {
   return (
     <>
       <View style={styles.animalID}>
-        <SimpleTypography text={'Nom : ' + name} />
-        <SimpleTypography text={'Rareté : ' + rarity} />
-        <SimpleTypography text={'Prix : ' + price} />
+        <SimpleTypography text={'Nom : ' + animal.name['name-EUfr']} />
+        <SimpleTypography text={'Rareté : ' + animal.availability.rarity} />
+        <SimpleTypography text={'Prix : ' + animal.price} />
       </View>
       <View style={styles.animalImageContainer}>
         <Image
           style={styles.animalImage}
           source={{
-            uri: icon,
+            uri: animal.icon_uri,
           }}
         />
       </View>


### PR DESCRIPTION
This PR aims to simplify the way animal lists are created and rendered.

+ a fix for month formatting

Before : The lists were in two components
Now : The list is unique and is called by the corresponding page.

All tests are updated according to the changes.